### PR TITLE
一度Ajaxで結果を取得している場合、すでに取得済みの結果を利用するように変更

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -3,6 +3,7 @@ export default{
   state : {
     userId: Number,
     result: {
+      id: Number,
       name: Text,
       difficulty: Text,
       score: Number,

--- a/src/views/Result.vue
+++ b/src/views/Result.vue
@@ -35,14 +35,18 @@
         axios.get('https://muscle-horror-api.herokuapp.com/results/' + this.id)
                 .then(response => {
                   let result = response.data.result;
+                  result.id = this.id;
                   store.setResult(result);
-                  this.name = store.state.result.name;
-                  this.score = store.state.result.score;
-                  this.life = store.state.result.life;
-                  this.analysis = store.state.result.analysis;
                   this.res = response;
-                  this.gotData = true;
+                  this.setVals();
                 })
+      },
+      setVals(){
+        this.name = store.state.result.name;
+        this.score = store.state.result.score;
+        this.life = store.state.result.life;
+        this.analysis = store.state.result.analysis;
+        this.gotData = true;
       },
       fiveStars(star) {
         if (0 <= star && star <= 5) {
@@ -55,7 +59,11 @@
       }
     },
     created() {
-      this.getVals();
+      if(this.id !== store.state.result.id) {
+        this.getVals();
+      }else{
+        this.setVals();
+      }
     }
   };
 </script>


### PR DESCRIPTION
storeのresultにidを保持させるようにして、resultを閲覧したときに比較、持っているデータなら再度Ajaxしないように変更しました